### PR TITLE
Cap openfilter dependency at <2.0.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@ Clipper release notes
 
 - Bump openfilter to 1.1.1
 - Bump openfilter to 1.1.2
+- Cap openfilter dependency at `<2.0.0` to prevent an unreviewed 2.x major from being pulled in.
 
 ## v0.1.17 - 2026-04-24
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-  "openfilter[all]>=1.1.2"
+  "openfilter[all]>=1.1.2,<2.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds an upper-version cap to the `openfilter[all]` dependency so a future openfilter 2.x major is not pulled in unreviewed. The lower bound stays at `>=1.1.1`.

```
openfilter[all]>=1.1.1  ->  openfilter[all]>=1.1.1,<2.0.0
```

This brings filter-crop in line with the other filters that already carry the `<2.0.0` cap (license-plate-detection, optical-character-recognition, sam3-detector). No behavioral change today: `>=1.1.1` already resolves to the current 1.1.x release; the cap only guards against an unreviewed major bump.

## Changes
- `pyproject.toml`: add `,<2.0.0` upper bound to the openfilter dependency.
- `RELEASE.md`: changelog entry under `[Unreleased]`.